### PR TITLE
Clarify website preview link

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -88,7 +88,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           command: pages deploy ./_docs --project-name=echild-docs --branch=preview --commit-dirty=true
           
-      - name: Print preview url
+      - name: LINK TO WEBSITE PREVIEW
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
         run: echo $DEPLOYMENT_URL


### PR DESCRIPTION
Making it clearer where to find the link to preview the website in the GitHub Actions logs.