### PR TITLE
Manually set branch name for Cloudflare

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
-          command: pages deploy ./_docs --project-name=echild-docs --commit-dirty=true
+          command: pages deploy ./_docs --project-name=echild-docs --branch=main --commit-dirty=true
 
 #      Google Cloud deploy
 #      - name: Authenticate on GCS


### PR DESCRIPTION
When the render/deploy workflow is triggered by a release, github correctly doesn't define a branch (just HEAD). Unfortunately Cloudflare therefore does not deploy to production, only preview. Manually specifying the branch as "main" should result in the desired behaviour.